### PR TITLE
Add changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Added
+- Add controller tests and service edge cases (#9)
+- Add StudentService unit tests (#8)
+- Codex/add inline documentation and javadoc comments (#6)
+- Added Spring boot app for testing.
+
+## Changed
+- Refactor service layer and controller (#5)
+- Update README with project description (#4)
+
+## Other
+- first commit
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Cordex-inno
 
 This repository contains experiments and documentation for Cordex's innovative solutions. More details will be added soon.
+
+## Generating the changelog
+Run `scripts/generate_changelog.py` to update `CHANGELOG.md` based on commit messages. Entries are grouped under Added, Changed, Fixed, Removed, and Other.

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate CHANGELOG entries from git history."""
+import subprocess
+import re
+from collections import defaultdict
+
+CATEGORY_PATTERNS = {
+    'Added': re.compile(r'\badd(ed|s)?\b', re.IGNORECASE),
+    'Fixed': re.compile(r'\bfix(ed|es)?\b|\bbug\b', re.IGNORECASE),
+    'Changed': re.compile(r'\b(change|update|refactor)(d|s)?\b', re.IGNORECASE),
+    'Removed': re.compile(r'\bremove(d|s)?\b', re.IGNORECASE),
+}
+
+
+def categorize(message: str) -> str:
+    for category, pattern in CATEGORY_PATTERNS.items():
+        if pattern.search(message):
+            return category
+    return 'Other'
+
+
+def gather_commit_messages() -> list:
+    output = subprocess.check_output([
+        'git', 'log', '--pretty=%s'
+    ], text=True)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def main():
+    commits = gather_commit_messages()
+    categorized = defaultdict(list)
+    for msg in commits:
+        category = categorize(msg)
+        categorized[category].append(msg)
+
+    with open('CHANGELOG.md', 'w') as changelog:
+        changelog.write('# Changelog\n\n')
+        for cat in ['Added', 'Changed', 'Fixed', 'Removed', 'Other']:
+            entries = categorized.get(cat)
+            if not entries:
+                continue
+            changelog.write(f'## {cat}\n')
+            for entry in entries:
+                changelog.write(f'- {entry}\n')
+            changelog.write('\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create a Python script `generate_changelog.py` that groups commit messages into categories
- generate an initial `CHANGELOG.md`
- document changelog generation in README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_6842d1faa5888324a42be88f82c097d2